### PR TITLE
:gear: Remappings Isolation and CI Enhancements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
     branches:
@@ -19,4 +20,4 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: make test
+        run: FOUNDRY_PROFILE=ci make test

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,5 +3,13 @@ ffi = false
 fuzz_runs = 256
 optimizer = true
 optimizer_runs = 1000000
-remappings = ["ds-test/=lib/ds-test/src/", "solmate/=lib/solmate/src/"]
+remappings = [
+  "ds-test/=lib/ds-test/src/",
+  "solmate/=lib/solmate/src/",
+  "weird-erc20/=lib/solmate/lib/weird-erc20/src/"
+]
 verbosity = 1
+
+# Extreme Fuzzing CI Profile :P
+[ci]
+fuzz_runs = 100_000

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,0 @@
-solmate/=lib/solmate/src/
-weird-erc20/=lib/solmate/lib/weird-erc20/src/
-ds-test/=lib/ds-test/src/


### PR DESCRIPTION
## Overview

Removes `remappings.txt` in favor of defining remappings in `foundry.toml`.

Creates a CI profile for extreme fuzzing for GitHub CI Action runs.